### PR TITLE
A couple more typos fixed + rewording

### DIFF
--- a/_posts/2017-03-23-coc.md
+++ b/_posts/2017-03-23-coc.md
@@ -6,7 +6,7 @@ date: 2017-03-23
 published: true
 ---
 
-The Freeko community is made up of a mixture of professionals and volunteers from all over the world, working on multiple aspects of providing tools and packages from coding through to marketing. Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to when they're using project resources.
+The Freeko community is made up of a mixture of professionals and volunteers from all over the world, working on multiple aspects of providing tools and packages from coding through to marketing. Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To prevent that, we have a few ground rules that we ask people to adhere to when they're using project resources.
 
 This isn't an exhaustive list of things that you can't do. Rather, take it in the spirit in which it's intended - a guide to make it easier to be excellent to each other.
 

--- a/_posts/2017-03-23-guidelines.md
+++ b/_posts/2017-03-23-guidelines.md
@@ -5,8 +5,8 @@ subtitle: Rules for contributing to our awesome project
 date: 2017-03-23
 ---
 
-In order to keep our project sane and usable for everyone we decided to set up
-couple of rules.
+In order to keep our project sane and usable for everyone, we decided to set up
+a couple of rules.
 
 Mostly these rules really just ensure that the packaging quality is at high
 enough standard and that we have someone to contact if problems arise.

--- a/aboutme.md
+++ b/aboutme.md
@@ -14,8 +14,8 @@ the provided software stack to better themselves and their skills.
 In order to achieve that, we also want the playground to be stable and reliable
 even for people interested in just using the stack rather than contributing.
 
-Or aim is to ensure stability and reliability by using the [maintenance process](https://en.opensuse.org/openSUSE:Maintenance_update_process)
-which will ensure a stable codebase for users from the stable distributions,
+Our aim is to ensure stability and reliability by using the [maintenance process](https://en.opensuse.org/openSUSE:Maintenance_update_process),
+which will help provide a solid codebase for users from the stable distributions,
 while allowing us to play (and break) the stack in our Devel repository that will
 be delivered to [openSUSE:Tumbleweed](https://en.opensuse.org/Portal:Tumbleweed).
 


### PR DESCRIPTION
In addition to the corrections that have already been merged in PR #1, I am taking care of some more typos I had overlooked before, plus adding some more suggestions.

The About page: rephrasing to avoid unnecessary repetition of the same words in one phrase.
Code of Conduct: fixing a discontinuity of meaning.

Feel free to disagree in case you think that some of my edits inadequately alter the meaning.